### PR TITLE
Fixes for compilation on Ubuntu 20.10

### DIFF
--- a/include/occa/mpi.hpp
+++ b/include/occa/mpi.hpp
@@ -4,6 +4,9 @@
 #  ifndef OCCA_MPI_HEADER
 #  define OCCA_MPI_HEADER
 
+// Workaround for https://github.com/open-mpi/ompi/issues/5157
+#define OMPI_SKIP_MPICXX 1
+
 #include <mpi.h>
 #include <vector>
 

--- a/src/tools/sys.cpp
+++ b/src/tools/sys.cpp
@@ -13,7 +13,6 @@
 #  include <sys/types.h>
 #  include <sys/stat.h>
 #  include <sys/syscall.h>
-#  include <sys/sysctl.h>
 #  include <sys/time.h>
 #  include <unistd.h>
 #  if (OCCA_OS & OCCA_LINUX_OS)
@@ -21,6 +20,7 @@
 #    include <sys/sysinfo.h>
 #  else // OCCA_MACOS_OS
 #    include <mach/mach_host.h>
+#    include <sys/sysctl.h>
 #    ifdef __clang__
 #      include <CoreServices/CoreServices.h>
 #      include <mach/mach_time.h>


### PR DESCRIPTION
The OpenMPI mpicxx workaround is the same as in https://github.com/Nek5000/nekRS/pull/235/commits/878b9ab346034c4af5e2ed41bfcc50db4d8a6657

It looks like my commits from https://github.com/Nek5000/nekRS/pull/235 are being incorporated into https://github.com/Nek5000/nekRS/pull/231 ?  This might be worth bringing into that too, then.